### PR TITLE
Add SumZero Godot project skeleton (Milestone 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,8 @@ android/local.properties
 
 # macOS
 .DS_Store
+
+# Godot project artifacts
+sumzero/.godot/
+sumzero/.import/
+sumzero/export/

--- a/sumzero/LICENSE
+++ b/sumzero/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SumZero Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sumzero/README.md
+++ b/sumzero/README.md
@@ -1,0 +1,65 @@
+# SumZero (Godot 4.4) – Milestone 1
+
+SumZero ist ein rundenbasiertes Puzzle-Strategiespiel, das in Godot 4.4 mit GDScript umgesetzt wird. Dieses Repository enthält den Projektbaum ab Milestone 1.
+
+## Projektstand
+- [x] **Milestone 1:** Grundgerüst mit Szenenstruktur, Grid-Rendering und Testkachel-Platzierung.
+- [ ] Milestone 2 – Legale Platzierung, Undo/Redo, Rotation/Flip.
+- [ ] Milestone 3 – Spielfluss und Siegbedingungen.
+- [ ] Milestone 4 – Figurenverwaltung.
+- [ ] Milestone 5 – KI Level 0–2.
+- [ ] Milestone 6 – Draft-Modus.
+- [ ] Milestone 7 – Fog-of-War.
+- [ ] Milestone 8 – Speed-Modus.
+- [ ] Milestone 9 – Missionen.
+- [ ] Milestone 10 – Settings und Save/Load.
+- [ ] Milestone 11 – Polishing.
+- [ ] Milestone 12 – Export-Profile.
+
+## Ausführung
+1. Godot 4.4.x starten.
+2. Den Projektordner `sumzero/` öffnen ("Import" → Ordner auswählen).
+3. Szene `scenes/Main.tscn` ausführen.
+
+## Steuerelemente (Milestone 1)
+- **Linksklick** auf das Grid: Toggle einer Testkachel.
+
+## Dateien & Struktur
+```
+sumzero/
+├── project.godot
+├── scenes/
+│   ├── Main.tscn
+│   ├── board/Board.tscn
+│   └── ui/UIRoot.tscn
+├── scripts/
+│   ├── Board.gd
+│   ├── Game.gd
+│   └── Shapes.gd
+├── settings/default_settings.json
+├── example_save.json
+├── README.md
+└── LICENSE
+```
+
+## Settings (Default)
+| Key | Wert |
+| --- | --- |
+| `board_width` / `board_height` | `14` |
+| `mode` | `basis` |
+| `ai_level` | `2` |
+| `contact_rule_corner_only` | `false` |
+| `speed_turn_seconds` | `15` |
+| `fog_radius` | `3` |
+| `draft_budget` | `70` |
+
+## Annahmen
+- Standardbrettgröße 14×14 wird für das UI-Layout angenommen.
+- Grid-Zellen sind 32px groß; spätere Milestones können eine dynamische Skalierung einführen.
+- Farben sind placeholder und bereits kontrastreich gestaltet.
+
+## Manuelle Tests (Milestone 1)
+1. Projekt öffnen und `Main.tscn` starten.
+2. Auf verschiedene Zellen klicken → Zellen wechseln zwischen leer und gefüllt.
+3. Fenstergröße verändern → Board bleibt sichtbar im vorgesehenen Bereich.
+

--- a/sumzero/example_save.json
+++ b/sumzero/example_save.json
@@ -1,0 +1,26 @@
+{
+  "mode": "basis",
+  "turn_index": 0,
+  "current_player": 0,
+  "board": {
+    "width": 14,
+    "height": 14,
+    "cells": []
+  },
+  "players": [
+    {
+      "available_shapes": [],
+      "used_shapes": []
+    },
+    {
+      "available_shapes": [],
+      "used_shapes": []
+    }
+  ],
+  "timers": {
+    "speed_mode_remaining": 15
+  },
+  "missions": {
+    "progress": {}
+  }
+}

--- a/sumzero/project.godot
+++ b/sumzero/project.godot
@@ -1,0 +1,9 @@
+[gd_resource type="ConfigFile" load_steps=2 format=3]
+
+[application]
+config/name="SumZero"
+run/main_scene="res://scenes/Main.tscn"
+config/features=PackedStringArray("4.4")
+
+[rendering]
+renderer/rendering_method="forward_plus"

--- a/sumzero/scenes/Main.tscn
+++ b/sumzero/scenes/Main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Game.gd" id="1_1"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_1")

--- a/sumzero/scenes/board/Board.tscn
+++ b/sumzero/scenes/board/Board.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Board.gd" id="1_1"]
+
+[node name="Board" type="Node2D"]
+script = ExtResource("1_1")

--- a/sumzero/scenes/piece/PiecePreview.tscn
+++ b/sumzero/scenes/piece/PiecePreview.tscn
@@ -1,0 +1,23 @@
+[gd_scene format=3 load_steps=1]
+
+[node name="PiecePreview" type="Control"]
+custom_minimum_size = Vector2(160, 160)
+anchors_preset = 8
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 160.0
+offset_bottom = 160.0
+
+[node name="InfoLabel" type="Label" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+text = "Piece Preview"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/sumzero/scenes/ui/UIRoot.tscn
+++ b/sumzero/scenes/ui/UIRoot.tscn
@@ -1,0 +1,62 @@
+[gd_scene format=3 load_steps=1]
+
+[node name="UIRoot" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Layout" type="VBoxContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+alignment = 1
+
+[node name="TopBar" type="HBoxContainer" parent="Layout"]
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 48)
+
+[node name="TopLabel" type="Label" parent="Layout/TopBar"]
+text = "SumZero Prototype"
+size_flags_horizontal = 3
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="BoardPane" type="Control" parent="Layout"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+mouse_filter = 2
+
+[node name="BoardHolder" type="Node2D" parent="Layout/BoardPane"]
+
+[node name="BottomBar" type="HBoxContainer" parent="Layout"]
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 48)
+
+[node name="BottomLabel" type="Label" parent="Layout/BottomBar"]
+text = "Milestone 1: Click cells to toggle test tile"
+size_flags_horizontal = 3
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="DraftPane" type="PanelContainer" parent="Layout"]
+visible = false
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 120)
+
+[node name="DraftLabel" type="Label" parent="Layout/DraftPane"]
+text = "Draft UI coming in later milestones"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/sumzero/scripts/Board.gd
+++ b/sumzero/scripts/Board.gd
@@ -1,0 +1,93 @@
+## Renders the board grid and handles simple click-based cell toggling for the prototype.
+class_name Board
+extends Node2D
+
+signal cell_state_changed(cell: Vector2i, filled: bool)
+
+const CELL_SIZE: int = 32
+const GRID_COLOR: Color = Color(0.35, 0.35, 0.4, 1.0)
+const BACKGROUND_COLOR: Color = Color(0.1, 0.1, 0.15, 1.0)
+const FILL_COLOR: Color = Color(0.85, 0.5, 0.2, 0.9)
+const BORDER_COLOR: Color = Color(0.65, 0.65, 0.75, 1.0)
+
+var board_size: Vector2i = Vector2i(14, 14)
+var _cells: Array[Array[bool]] = []
+
+func _ready() -> void:
+    ## Prepare the board matrix and enable input processing.
+    if _cells.is_empty():
+        _initialize_cells()
+    set_process_unhandled_input(true)
+    queue_redraw()
+
+func set_board_size(size: Vector2i) -> void:
+    ## Sets the board dimensions and reinitialises cell data.
+    board_size = size
+    _initialize_cells()
+    queue_redraw()
+
+func reset() -> void:
+    ## Clears all filled cells.
+    for y in range(board_size.y):
+        for x in range(board_size.x):
+            _cells[y][x] = false
+    queue_redraw()
+
+func get_board_pixel_size() -> Vector2:
+    ## Returns the pixel dimensions of the board.
+    return Vector2(board_size.x * CELL_SIZE, board_size.y * CELL_SIZE)
+
+func _draw() -> void:
+    ## Draws the board background, grid, and toggled cells.
+    var size: Vector2 = get_board_pixel_size()
+    draw_rect(Rect2(Vector2.ZERO, size), BACKGROUND_COLOR, true)
+    draw_rect(Rect2(Vector2.ZERO, size), BORDER_COLOR, false, 2.0)
+
+    for x in range(board_size.x + 1):
+        var start: Vector2 = Vector2(x * CELL_SIZE, 0)
+        var end: Vector2 = Vector2(x * CELL_SIZE, size.y)
+        draw_line(start, end, GRID_COLOR, x % 5 == 0 ? 1.5 : 1.0)
+
+    for y in range(board_size.y + 1):
+        var start_y: Vector2 = Vector2(0, y * CELL_SIZE)
+        var end_y: Vector2 = Vector2(size.x, y * CELL_SIZE)
+        draw_line(start_y, end_y, GRID_COLOR, y % 5 == 0 ? 1.5 : 1.0)
+
+    for y in range(board_size.y):
+        for x in range(board_size.x):
+            if _cells[y][x]:
+                var rect: Rect2 = Rect2(Vector2(x, y) * CELL_SIZE, Vector2(CELL_SIZE, CELL_SIZE))
+                draw_rect(rect.grow(-3.0), FILL_COLOR, true)
+
+func _unhandled_input(event: InputEvent) -> void:
+    ## Toggles a cell when the left mouse button is pressed.
+    if event is InputEventMouseButton and event.button_index == MouseButton.LEFT and event.pressed:
+        var mouse_event := event as InputEventMouseButton
+        var local_pos: Vector2 = to_local(mouse_event.position)
+        var cell: Vector2i = _position_to_cell(local_pos)
+        if _is_cell_in_bounds(cell):
+            _toggle_cell(cell)
+            queue_redraw()
+
+func _toggle_cell(cell: Vector2i) -> void:
+    ## Flips a cell state and emits the change.
+    var value: bool = not _cells[cell.y][cell.x]
+    _cells[cell.y][cell.x] = value
+    cell_state_changed.emit(cell, value)
+
+func _initialize_cells() -> void:
+    ## Builds a matrix representing board occupancy.
+    _cells.clear()
+    for y in range(board_size.y):
+        var row: Array[bool] = []
+        for x in range(board_size.x):
+            row.append(false)
+        _cells.append(row)
+
+func _position_to_cell(point: Vector2) -> Vector2i:
+    ## Converts a pixel position into board coordinates.
+    return Vector2i(floor(point.x / CELL_SIZE), floor(point.y / CELL_SIZE))
+
+func _is_cell_in_bounds(cell: Vector2i) -> bool:
+    ## Checks whether a cell coordinate exists on the board.
+    return cell.x >= 0 and cell.y >= 0 and cell.x < board_size.x and cell.y < board_size.y

--- a/sumzero/scripts/Game.gd
+++ b/sumzero/scripts/Game.gd
@@ -1,0 +1,19 @@
+## Handles high-level scene setup and acts as entry point for the prototype.
+extends Node2D
+
+const BOARD_SCENE: PackedScene = preload("res://scenes/board/Board.tscn")
+const UI_SCENE: PackedScene = preload("res://scenes/ui/UIRoot.tscn")
+
+var board: Board
+var ui_root: Control
+
+func _ready() -> void:
+    ## Instantiate UI and board scaffolding for milestone 1.
+    ui_root = UI_SCENE.instantiate()
+    add_child(ui_root)
+
+    board = BOARD_SCENE.instantiate() as Board
+    var board_holder: Node2D = ui_root.get_node("Layout/BoardPane/BoardHolder") as Node2D
+    board_holder.add_child(board)
+    board.position = Vector2.ZERO
+    board.set_board_size(Vector2i(14, 14))

--- a/sumzero/scripts/Shapes.gd
+++ b/sumzero/scripts/Shapes.gd
@@ -1,0 +1,69 @@
+## Contains canonical polyomino definitions and transformation helpers.
+class_name Shapes
+extends Object
+
+const SHAPES: Dictionary = {
+    "domino": [Vector2i(0, 0), Vector2i(1, 0)],
+    "tetromino_i": [Vector2i(0, 0), Vector2i(1, 0), Vector2i(2, 0), Vector2i(3, 0)],
+    "tetromino_o": [Vector2i(0, 0), Vector2i(1, 0), Vector2i(0, 1), Vector2i(1, 1)],
+    "tetromino_t": [Vector2i(1, 0), Vector2i(0, 1), Vector2i(1, 1), Vector2i(2, 1)],
+    "tetromino_s": [Vector2i(1, 0), Vector2i(2, 0), Vector2i(0, 1), Vector2i(1, 1)],
+    "tetromino_z": [Vector2i(0, 0), Vector2i(1, 0), Vector2i(1, 1), Vector2i(2, 1)],
+    "tetromino_l": [Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2), Vector2i(1, 2)],
+    "tetromino_j": [Vector2i(1, 0), Vector2i(1, 1), Vector2i(1, 2), Vector2i(0, 2)]
+}
+
+static func list_shapes() -> PackedStringArray:
+    ## Returns identifiers for all registered shapes.
+    var keys: Array = SHAPES.keys()
+    keys.sort()
+    return PackedStringArray(keys)
+
+static func get_shape_cells(shape_id: String) -> Array[Vector2i]:
+    ## Returns a copy of the cell list for the given shape.
+    if not SHAPES.has(shape_id):
+        return []
+    var cells: Array[Vector2i] = []
+    for cell in SHAPES[shape_id]:
+        cells.append(cell)
+    return cells
+
+static func rotate_cells(cells: Array[Vector2i], quarter_turns: int) -> Array[Vector2i]:
+    ## Rotates a shape in 90-degree increments.
+    var turns: int = ((quarter_turns % 4) + 4) % 4
+    var rotated: Array[Vector2i] = []
+    for cell in cells:
+        var result: Vector2i = cell
+        match turns:
+            0:
+                result = cell
+            1:
+                result = Vector2i(-cell.y, cell.x)
+            2:
+                result = Vector2i(-cell.x, -cell.y)
+            3:
+                result = Vector2i(cell.y, -cell.x)
+        rotated.append(result)
+    return _normalize(rotated)
+
+static func mirror_cells(cells: Array[Vector2i], horizontal: bool = true) -> Array[Vector2i]:
+    ## Mirrors a shape either horizontally or vertically.
+    var mirrored: Array[Vector2i] = []
+    for cell in cells:
+        var result: Vector2i = horizontal ? Vector2i(-cell.x, cell.y) : Vector2i(cell.x, -cell.y)
+        mirrored.append(result)
+    return _normalize(mirrored)
+
+static func _normalize(cells: Array[Vector2i]) -> Array[Vector2i]:
+    ## Normalizes a list of cells so the minimum coordinate is at (0, 0).
+    if cells.is_empty():
+        return []
+    var min_x: int = cells[0].x
+    var min_y: int = cells[0].y
+    for cell in cells:
+        min_x = min(min_x, cell.x)
+        min_y = min(min_y, cell.y)
+    var normalized: Array[Vector2i] = []
+    for cell in cells:
+        normalized.append(Vector2i(cell.x - min_x, cell.y - min_y))
+    return normalized

--- a/sumzero/settings/default_settings.json
+++ b/sumzero/settings/default_settings.json
@@ -1,0 +1,10 @@
+{
+  "board_width": 14,
+  "board_height": 14,
+  "mode": "basis",
+  "ai_level": 2,
+  "contact_rule_corner_only": false,
+  "speed_turn_seconds": 15,
+  "fog_radius": 3,
+  "draft_budget": 70
+}


### PR DESCRIPTION
## Summary
- add a new Godot 4.4 SumZero project skeleton with required scenes and folder structure
- implement the board renderer with clickable test tiles and provide initial shape definitions
- document project assumptions, defaults, and milestone-1 manual tests in a dedicated README

## Testing
- not run (Godot project)


------
https://chatgpt.com/codex/tasks/task_e_68c8666881d483278762344a6da20787