### PR TITLE
Add board placement logic and ghost preview controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # BuddyAlert App
 
 Minimalistische Sicherheits-App mit Community-Fokus.
+
+## Steuerung & Spielfunktionen
+
+Die Godot-Boardszene unterstützt jetzt eine flexible Vorschau sowie Undo/Redo.
+
+* **Rotation & Flip**: `R` rotiert das aktuelle Shape im Uhrzeigersinn, `F` spiegelt es horizontal.
+* **Verschieben**: Mit den Pfeiltasten wird die Ghost-Vorschau pro Feld bewegt. Ungültige Positionen färben sich rot.
+* **Platzieren**: `Enter` oder `Leertaste` setzen die Figur, sofern der Platz frei und im Board liegt.
+* **UI-Buttons**: Die Buttons „Rotate“, „Flip“, „Undo“ und „Redo“ im BottomBar-Panel rufen die gleichen Funktionen auf.
+
+## Manuelle Testschritte
+
+1. **Platzierungsprüfung**
+   1. Wähle einen Shape (`square`, `line`, `l`, `t`) und bewege ihn an den Rand.
+   2. Vergewissere dich, dass die Vorschau rot wird, sobald der Shape das Board verlässt oder eine belegte Zelle überlappt.
+   3. Bestätige, dass das Setzen (`Enter` oder Button) in diesem Zustand verweigert wird.
+2. **Undo/Redo**
+   1. Platziere mehrere Shapes.
+   2. Betätige „Undo“ (Button oder `Ctrl+Z`) und prüfe, dass der letzte Zug zurückgenommen wird.
+   3. Betätige „Redo“ (Button, `Ctrl+Y` oder `Ctrl+Shift+Z`) und kontrolliere, dass der entfernte Shape wieder erscheint.
+3. **Ghost-Vorschau**
+   1. Rotiere (`R`) und flippe (`F`) das aktuelle Shape; die Vorschau soll die Änderung direkt darstellen.
+   2. Verschiebe die Figur mit den Pfeiltasten und beobachte, wie die transparente Vorschau die Zielposition anzeigt.
+   3. Bestätige, dass die Vorschau nach jeder Platzierung automatisch auf der aktuellen Shape-Konfiguration bleibt.

--- a/scenes/piece/PiecePreview.gd
+++ b/scenes/piece/PiecePreview.gd
@@ -1,0 +1,43 @@
+extends Node2D
+class_name PiecePreview
+
+@export var cell_size: float = 32.0
+@export var valid_color: Color = Color(0.3, 0.9, 0.9, 0.45)
+@export var invalid_color: Color = Color(1.0, 0.3, 0.3, 0.45)
+@export var outline_color: Color = Color(1.0, 1.0, 1.0, 0.7)
+
+var _cells: Array[Vector2i] = []
+var _is_valid: bool = true
+
+func set_cells(cells: Array[Vector2i]) -> void:
+    _cells.clear()
+    for cell in cells:
+        _cells.append(Vector2i(cell))
+    queue_redraw()
+
+func clear() -> void:
+    _cells.clear()
+    queue_redraw()
+
+func set_valid_state(valid: bool) -> void:
+    if _is_valid == valid:
+        return
+    _is_valid = valid
+    queue_redraw()
+
+func set_cell_size(size: float) -> void:
+    if cell_size == size:
+        return
+    cell_size = size
+    queue_redraw()
+
+func _draw() -> void:
+    if _cells.is_empty():
+        return
+
+    var fill_color := valid_color if _is_valid else invalid_color
+    for cell in _cells:
+        var top_left := Vector2(cell.x, cell.y) * cell_size
+        var rect := Rect2(top_left, Vector2(cell_size, cell_size))
+        draw_rect(rect, fill_color)
+        draw_rect(rect, outline_color, false, 1.0)

--- a/scenes/piece/PiecePreview.tscn
+++ b/scenes/piece/PiecePreview.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3 uid="uid://cn0p7cuo33wp6"]
+
+[ext_resource type="Script" path="res://scenes/piece/PiecePreview.gd" id="1"]
+
+[node name="PiecePreview" type="Node2D"]
+script = ExtResource("1")
+z_index = 100

--- a/scenes/ui/BottomBar.tscn
+++ b/scenes/ui/BottomBar.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=2 format=3 uid="uid://dkw31dr27xr6s"]
+
+[ext_resource type="Script" path="res://scripts/ui/BottomBar.gd" id="1"]
+
+[node name="BottomBar" type="HBoxContainer"]
+script = ExtResource("1")
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="RotateButton" type="Button" parent="."]
+text = "Rotate (R)"
+
+[node name="FlipButton" type="Button" parent="."]
+text = "Flip (F)"
+
+[node name="UndoButton" type="Button" parent="."]
+text = "Undo"
+disabled = true
+
+[node name="RedoButton" type="Button" parent="."]
+text = "Redo"
+disabled = true

--- a/scripts/Board.gd
+++ b/scripts/Board.gd
@@ -1,0 +1,342 @@
+extends Node2D
+class_name Board
+
+signal history_changed(has_undo: bool, has_redo: bool)
+signal preview_state_changed(is_valid: bool)
+
+const Shapes := preload("res://scripts/Shapes.gd")
+const PiecePreviewScene := preload("res://scenes/piece/PiecePreview.tscn")
+
+@export var board_size: Vector2i = Vector2i(10, 10)
+@export var cell_size: float = 32.0
+@export var initial_shape: String = "square"
+@export var preview_enabled: bool = true
+@export var preview_start_position: Vector2i = Vector2i.ZERO
+
+var current_shape_id: String
+var _rotation_steps: int = 0
+var _is_flipped: bool = false
+var _preview_position: Vector2i = Vector2i.ZERO
+var _grid: Array = []
+var _occupied_cells: Dictionary = {}
+var _placements: Array = []
+var _undo_stack: Array = []
+var _redo_stack: Array = []
+var _current_offsets: Array = []
+var _preview_instance: PiecePreview
+var _shape_color_cache: Dictionary = {}
+
+const _PALETTE := [
+    Color(0.94, 0.43, 0.36, 0.85),
+    Color(0.44, 0.75, 0.93, 0.85),
+    Color(0.91, 0.77, 0.35, 0.85),
+    Color(0.47, 0.82, 0.50, 0.85),
+    Color(0.78, 0.52, 0.88, 0.85),
+    Color(0.96, 0.64, 0.38, 0.85),
+]
+
+func _ready() -> void:
+    _init_grid()
+    current_shape_id = _resolve_initial_shape()
+    _preview_position = preview_start_position
+    _create_preview_instance()
+    update_preview()
+    _notify_history_change()
+
+func _init_grid() -> void:
+    _grid.clear()
+    _occupied_cells.clear()
+    _placements.clear()
+    _undo_stack.clear()
+    _redo_stack.clear()
+
+    for x in range(board_size.x):
+        var column: Array[bool] = []
+        for y in range(board_size.y):
+            column.append(false)
+        _grid.append(column)
+    queue_redraw()
+
+func _resolve_initial_shape() -> String:
+    if Shapes.has_shape(initial_shape):
+        return initial_shape
+    if Shapes.SHAPES.is_empty():
+        return ""
+    return Shapes.SHAPES.keys()[0]
+
+func _create_preview_instance() -> void:
+    if not PiecePreviewScene:
+        return
+    if _preview_instance:
+        _preview_instance.queue_free()
+    _preview_instance = PiecePreviewScene.instantiate()
+    add_child(_preview_instance)
+    _preview_instance.set_cell_size(cell_size)
+    _preview_instance.visible = preview_enabled
+    _preview_instance.z_index = 100
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventKey and event.pressed and not event.echo:
+        var key_event := event as InputEventKey
+        match key_event.keycode:
+            KEY_R:
+                rotate_clockwise()
+            KEY_F:
+                toggle_flip()
+            KEY_LEFT:
+                move_preview(Vector2i(-1, 0))
+            KEY_RIGHT:
+                move_preview(Vector2i(1, 0))
+            KEY_UP:
+                move_preview(Vector2i(0, -1))
+            KEY_DOWN:
+                move_preview(Vector2i(0, 1))
+            KEY_SPACE, KEY_ENTER:
+                place_current_piece()
+            KEY_Z:
+                if key_event.ctrl_pressed:
+                    if key_event.shift_pressed:
+                        redo()
+                    else:
+                        undo()
+            KEY_Y:
+                if key_event.ctrl_pressed:
+                    redo()
+
+func set_current_shape(shape_id: String) -> void:
+    if shape_id == current_shape_id:
+        return
+    if not Shapes.has_shape(shape_id):
+        push_warning("Shape '%s' is not defined." % shape_id)
+        return
+    current_shape_id = shape_id
+    _rotation_steps = 0
+    _is_flipped = false
+    update_preview()
+
+func rotate_clockwise() -> void:
+    _rotation_steps = (_rotation_steps + 1) % 4
+    update_preview()
+
+func rotate_counter_clockwise() -> void:
+    _rotation_steps = (_rotation_steps + 3) % 4
+    update_preview()
+
+func toggle_flip() -> void:
+    _is_flipped = not _is_flipped
+    update_preview()
+
+func set_flip(value: bool) -> void:
+    if _is_flipped == value:
+        return
+    _is_flipped = value
+    update_preview()
+
+func move_preview(delta: Vector2i) -> void:
+    _preview_position += delta
+    update_preview()
+
+func set_preview_position(position: Vector2i) -> void:
+    _preview_position = position
+    update_preview()
+
+func get_preview_position() -> Vector2i:
+    return _preview_position
+
+func get_preview_cells() -> Array[Vector2i]:
+    return _get_world_cells(_preview_position)
+
+func can_place_current_preview() -> bool:
+    return can_place_at(_preview_position)
+
+func place_current_piece() -> bool:
+    if _current_offsets.is_empty():
+        return false
+    var world_cells := _get_world_cells(_preview_position)
+    if not _is_within_bounds(world_cells) or not _are_cells_free(world_cells):
+        return false
+
+    var placement := {
+        "shape_id": current_shape_id,
+        "rotation": _rotation_steps,
+        "flipped": _is_flipped,
+        "position": Vector2i(_preview_position),
+        "cells": world_cells,
+        "color": _get_color_for_shape(current_shape_id),
+    }
+    _apply_placement(placement)
+    _undo_stack.append(placement)
+    _redo_stack.clear()
+    _notify_history_change()
+    update_preview()
+    return true
+
+func undo() -> bool:
+    if _undo_stack.is_empty():
+        return false
+    var placement = _undo_stack.pop_back()
+    _remove_placement(placement)
+    _redo_stack.append(placement)
+    _notify_history_change()
+    update_preview()
+    return true
+
+func redo() -> bool:
+    if _redo_stack.is_empty():
+        return false
+    var placement = _redo_stack.pop_back()
+    _apply_placement(placement)
+    _undo_stack.append(placement)
+    _notify_history_change()
+    update_preview()
+    return true
+
+func has_undo() -> bool:
+    return not _undo_stack.is_empty()
+
+func has_redo() -> bool:
+    return not _redo_stack.is_empty()
+
+func can_place_at(position: Vector2i) -> bool:
+    if _current_offsets.is_empty():
+        return false
+    var world_cells := _get_world_cells(position)
+    return _is_within_bounds(world_cells) and _are_cells_free(world_cells)
+
+func is_within_bounds(cells: Array[Vector2i]) -> bool:
+    return _is_within_bounds(cells)
+
+func are_cells_free(cells: Array[Vector2i]) -> bool:
+    return _are_cells_free(cells)
+
+func is_placement_valid(cells: Array[Vector2i]) -> bool:
+    return _is_within_bounds(cells) and _are_cells_free(cells)
+
+func clear_board() -> void:
+    _init_grid()
+    update_preview()
+    _notify_history_change()
+
+func update_preview() -> void:
+    if current_shape_id == "" or not Shapes.has_shape(current_shape_id):
+        _current_offsets = []
+    else:
+        _current_offsets = Shapes.get_transformed_shape(current_shape_id, _rotation_steps, _is_flipped)
+
+    _clamp_preview_position()
+
+    var valid := can_place_at(_preview_position)
+    if _preview_instance:
+        _preview_instance.visible = preview_enabled and not _current_offsets.is_empty()
+        _preview_instance.set_cell_size(cell_size)
+        _preview_instance.position = Vector2(_preview_position) * cell_size
+        _preview_instance.set_cells(_current_offsets)
+        _preview_instance.set_valid_state(valid)
+
+    emit_signal("preview_state_changed", valid)
+    queue_redraw()
+
+func _clamp_preview_position() -> void:
+    if board_size.x <= 0 or board_size.y <= 0:
+        _preview_position = Vector2i.ZERO
+        return
+    var size := _get_shape_size()
+    var width := max(size.x, 1)
+    var height := max(size.y, 1)
+    var max_x := max(0, board_size.x - width)
+    var max_y := max(0, board_size.y - height)
+    _preview_position.x = clamp(_preview_position.x, 0, max_x)
+    _preview_position.y = clamp(_preview_position.y, 0, max_y)
+
+func _get_shape_size() -> Vector2i:
+    if _current_offsets.is_empty():
+        return Vector2i.ONE
+    var max_x := 0
+    var max_y := 0
+    for cell in _current_offsets:
+        max_x = max(max_x, cell.x)
+        max_y = max(max_y, cell.y)
+    return Vector2i(max_x + 1, max_y + 1)
+
+func _get_world_cells(position: Vector2i) -> Array[Vector2i]:
+    var cells: Array[Vector2i] = []
+    for offset in _current_offsets:
+        cells.append(position + offset)
+    return cells
+
+func _is_within_bounds(cells: Array[Vector2i]) -> bool:
+    for cell in cells:
+        if cell.x < 0 or cell.y < 0:
+            return false
+        if cell.x >= board_size.x or cell.y >= board_size.y:
+            return false
+    return true
+
+func _are_cells_free(cells: Array[Vector2i]) -> bool:
+    for cell in cells:
+        if cell.x < 0 or cell.x >= board_size.x:
+            return false
+        if cell.y < 0 or cell.y >= board_size.y:
+            return false
+        if _grid[cell.x][cell.y]:
+            return false
+    return true
+
+func _apply_placement(placement: Dictionary) -> void:
+    if not _placements.has(placement):
+        _placements.append(placement)
+    for cell in placement["cells"]:
+        _set_cell(cell, true, placement["color"])
+    queue_redraw()
+
+func _remove_placement(placement: Dictionary) -> void:
+    _placements.erase(placement)
+    for cell in placement["cells"]:
+        _set_cell(cell, false)
+    queue_redraw()
+
+func _set_cell(cell: Vector2i, occupied: bool, color: Color = Color.WHITE) -> void:
+    if cell.x < 0 or cell.x >= board_size.x:
+        return
+    if cell.y < 0 or cell.y >= board_size.y:
+        return
+    _grid[cell.x][cell.y] = occupied
+    var key := Vector2i(cell)
+    if occupied:
+        _occupied_cells[key] = color
+    else:
+        _occupied_cells.erase(key)
+
+func _get_color_for_shape(shape_id: String) -> Color:
+    if _shape_color_cache.has(shape_id):
+        return _shape_color_cache[shape_id]
+    if _PALETTE.is_empty():
+        return Color.WHITE
+    var index := abs(hash(shape_id)) % _PALETTE.size()
+    var color := _PALETTE[index]
+    _shape_color_cache[shape_id] = color
+    return color
+
+func _notify_history_change() -> void:
+    emit_signal("history_changed", has_undo(), has_redo())
+
+func _draw() -> void:
+    var board_pixel_size := Vector2(board_size.x * cell_size, board_size.y * cell_size)
+    draw_rect(Rect2(Vector2.ZERO, board_pixel_size), Color(0.08, 0.08, 0.08))
+
+    var line_color := Color(0.3, 0.3, 0.35, 0.75)
+    for x in range(board_size.x + 1):
+        var pos_x := x * cell_size
+        draw_line(Vector2(pos_x, 0), Vector2(pos_x, board_pixel_size.y), line_color, 1.0)
+    for y in range(board_size.y + 1):
+        var pos_y := y * cell_size
+        draw_line(Vector2(0, pos_y), Vector2(board_pixel_size.x, pos_y), line_color, 1.0)
+
+    for cell_key in _occupied_cells.keys():
+        var cell: Vector2i = cell_key
+        var color: Color = _occupied_cells[cell_key]
+        var top_left := Vector2(cell.x, cell.y) * cell_size
+        var rect := Rect2(top_left, Vector2(cell_size, cell_size))
+        draw_rect(rect, color)
+        var outline := Color(color.r, color.g, color.b, min(color.a + 0.2, 1.0))
+        draw_rect(rect, outline, false, 1.0)

--- a/scripts/Shapes.gd
+++ b/scripts/Shapes.gd
@@ -1,0 +1,99 @@
+extends Resource
+class_name Shapes
+
+## Stores the raw shape definitions and exposes helpers to transform them.
+## Shapes are described as lists of Vector2i offsets where (0, 0) represents the
+## top-left corner of the piece in its default orientation.
+const SHAPES := {
+    "square": [
+        Vector2i(0, 0), Vector2i(1, 0),
+        Vector2i(0, 1), Vector2i(1, 1),
+    ],
+    "line": [
+        Vector2i(0, 0), Vector2i(1, 0), Vector2i(2, 0), Vector2i(3, 0)
+    ],
+    "l": [
+        Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2), Vector2i(1, 2)
+    ],
+    "t": [
+        Vector2i(0, 0), Vector2i(1, 0), Vector2i(2, 0), Vector2i(1, 1)
+    ],
+}
+
+## Returns true when a shape with the given name exists.
+static func has_shape(name: String) -> bool:
+    return SHAPES.has(name)
+
+## Returns a deep copy of the base cell list for the given shape name.
+static func get_shape(name: String) -> Array[Vector2i]:
+    if not SHAPES.has(name):
+        return []
+    var duplicated: Array[Vector2i] = []
+    for cell in SHAPES[name]:
+        duplicated.append(Vector2i(cell))
+    return duplicated
+
+## Rotates a set of cells by the given number of clockwise 90° steps.
+static func rotate_cells(cells: Array[Vector2i], steps: int = 1) -> Array[Vector2i]:
+    var normalized_steps := posmod(steps, 4)
+    if normalized_steps == 0:
+        return _normalize_cells(cells)
+
+    var rotated: Array[Vector2i] = []
+    for cell in cells:
+        var transformed := Vector2i(cell)
+        for i in range(normalized_steps):
+            transformed = Vector2i(transformed.y, -transformed.x)
+        rotated.append(transformed)
+    return _normalize_cells(rotated)
+
+## Flips a set of cells. By default the cells are mirrored horizontally.
+static func flip_cells(cells: Array[Vector2i], horizontal: bool = true) -> Array[Vector2i]:
+    var flipped: Array[Vector2i] = []
+    for cell in cells:
+        var x := -cell.x if horizontal else cell.x
+        var y := cell.y if horizontal else -cell.y
+        flipped.append(Vector2i(x, y))
+    return _normalize_cells(flipped)
+
+## Applies rotation and flip to the provided cell list.
+static func transform_cells(
+        cells: Array[Vector2i],
+        rotation_steps: int = 0,
+        flipped: bool = false,
+        horizontal: bool = true) -> Array[Vector2i]:
+    var transformed: Array[Vector2i] = []
+    for cell in cells:
+        transformed.append(Vector2i(cell))
+
+    if flipped:
+        transformed = flip_cells(transformed, horizontal)
+    if rotation_steps % 4 != 0:
+        transformed = rotate_cells(transformed, rotation_steps)
+    return _normalize_cells(transformed)
+
+## Helper to fetch a transformed shape in one call.
+static func get_transformed_shape(
+        name: String,
+        rotation_steps: int = 0,
+        flipped: bool = false,
+        horizontal: bool = true) -> Array[Vector2i]:
+    var base := get_shape(name)
+    if base.is_empty():
+        return []
+    return transform_cells(base, rotation_steps, flipped, horizontal)
+
+static func _normalize_cells(cells: Array[Vector2i]) -> Array[Vector2i]:
+    if cells.is_empty():
+        return []
+
+    var min_x := cells[0].x
+    var min_y := cells[0].y
+    for cell in cells:
+        min_x = min(min_x, cell.x)
+        min_y = min(min_y, cell.y)
+
+    var normalized: Array[Vector2i] = []
+    for cell in cells:
+        normalized.append(Vector2i(cell.x - min_x, cell.y - min_y))
+    return normalized

--- a/scripts/ui/BottomBar.gd
+++ b/scripts/ui/BottomBar.gd
@@ -1,0 +1,75 @@
+extends HBoxContainer
+class_name BottomBar
+
+@export var board_path: NodePath
+
+var _board: Board = null
+
+@onready var _rotate_button: Button = $RotateButton
+@onready var _flip_button: Button = $FlipButton
+@onready var _undo_button: Button = $UndoButton
+@onready var _redo_button: Button = $RedoButton
+
+func _ready() -> void:
+    _rotate_button.pressed.connect(_on_rotate_pressed)
+    _flip_button.pressed.connect(_on_flip_pressed)
+    _undo_button.pressed.connect(_on_undo_pressed)
+    _redo_button.pressed.connect(_on_redo_pressed)
+    _resolve_board()
+    _update_button_states()
+
+func _exit_tree() -> void:
+    if _board and _board.history_changed.is_connected(_on_board_history_changed):
+        _board.history_changed.disconnect(_on_board_history_changed)
+
+func set_board(board: Board) -> void:
+    if _board == board:
+        return
+    if _board and _board.history_changed.is_connected(_on_board_history_changed):
+        _board.history_changed.disconnect(_on_board_history_changed)
+    _board = board
+    if _board:
+        _board.history_changed.connect(_on_board_history_changed)
+    _update_button_states()
+
+func _resolve_board() -> void:
+    if board_path == NodePath():
+        return
+    var node := get_node_or_null(board_path)
+    if node is Board:
+        set_board(node)
+    elif node:
+        push_warning("Node '%s' is not a Board instance." % node.name)
+
+func _update_button_states() -> void:
+    var has_board := _board != null
+    _rotate_button.disabled = not has_board
+    _flip_button.disabled = not has_board
+    if has_board:
+        _undo_button.disabled = not _board.has_undo()
+        _redo_button.disabled = not _board.has_redo()
+    else:
+        _undo_button.disabled = true
+        _redo_button.disabled = true
+
+func _on_rotate_pressed() -> void:
+    if _board:
+        _board.rotate_clockwise()
+
+func _on_flip_pressed() -> void:
+    if _board:
+        _board.toggle_flip()
+
+func _on_undo_pressed() -> void:
+    if _board:
+        _board.undo()
+
+func _on_redo_pressed() -> void:
+    if _board:
+        _board.redo()
+
+func _on_board_history_changed(has_undo: bool, has_redo: bool) -> void:
+    _undo_button.disabled = not has_undo
+    _redo_button.disabled = not has_redo
+    _rotate_button.disabled = _board == null
+    _flip_button.disabled = _board == null


### PR DESCRIPTION
## Summary
- add a Board script with placement validation, undo/redo history, keyboard shortcuts, and ghost preview management
- provide Shapes helpers plus PiecePreview scene to render rotated/flipped pieces for the board
- wire a BottomBar UI to rotation/flip/undo/redo actions and document the new controls and manual test steps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d81f7c208327b472ec3893e5194d