### PR TITLE
feat: add board placement validation and preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # BuddyAlert App
 
 Minimalistische Sicherheits-App mit Community-Fokus.
+
+## Steuerung der Puzzle-Prototyp-Szene
+
+Im Godot-Prototyp lassen sich die aktiven Figuren nun direkt am Board transformieren:
+
+- `R`: Figur um 90° im Uhrzeigersinn drehen.
+- `Shift + R`: Figur gegen den Uhrzeigersinn drehen.
+- `F`: Figur horizontal spiegeln (Flip).
+- `Strg + Z`: Letzte Platzierung rückgängig machen (Undo).
+- `Strg + Shift + Z` bzw. `Strg + Y`: Wiederholt die letzte Rücknahme (Redo).
+
+Die gleichen Aktionen können optional über angebundene Buttons ausgelöst werden (`rotate`, `flip`, `undo`, `redo`).
+
+## Manuelle Tests
+
+1. Projekt in Godot öffnen und die Board-Szene starten.
+2. Eine beliebige Figur auswählen, die Vorschau (Ghost) sollte als halbtransparente Überlagerung erscheinen.
+3. `R` drücken und prüfen, dass sich Vorschau **und** Platzierung im Uhrzeigersinn drehen. Anschließend mit `Shift + R` zurückdrehen.
+4. `F` drücken und sicherstellen, dass die Vorschau gespiegelt wird und der Flip auch bei einer Platzierung angewendet wird.
+5. Eine Figur auf dem Board platzieren. Mit `Strg + Z` rückgängig machen und kontrollieren, dass das Feld wieder frei ist.
+6. Direkt danach `Strg + Shift + Z` oder `Strg + Y` betätigen, um die Platzierung erneut herzustellen.
+7. Mehrere Platzierungen hintereinander durchführen, dann mehrfach `Undo` drücken und schließlich `Redo`, um die Stapel-Funktionalität zu verifizieren.
+8. Optional die an die Buttons gebundenen Aktionen betätigen und sicherstellen, dass sie dieselbe Logik wie die Hotkeys verwenden.

--- a/scenes/piece/PiecePreview.gd
+++ b/scenes/piece/PiecePreview.gd
@@ -1,0 +1,43 @@
+extends Node2D
+class_name PiecePreview
+
+@export var cell_size: float = 32.0
+@export var fill_color: Color = Color(1, 1, 1, 0.25)
+@export var outline_color: Color = Color(1, 1, 1, 0.6)
+@export var outline_thickness: float = 1.0
+@export var offset: Vector2 = Vector2.ZERO
+
+var _cells: Array = []
+var _origin: Vector2 = Vector2.ZERO
+var _cell_size: float = cell_size
+
+func show_shape(shape_cells: Array, board_origin: Vector2 = Vector2.ZERO, override_cell_size: float = -1.0) -> void:
+    _cells.clear()
+    for entry in shape_cells:
+        if entry is Vector2i:
+            _cells.append(Vector2(entry))
+        elif entry is Vector2:
+            _cells.append(entry)
+        elif entry is Array and entry.size() >= 2:
+            _cells.append(Vector2(float(entry[0]), float(entry[1])))
+        elif entry is Dictionary and entry.has("x") and entry.has("y"):
+            _cells.append(Vector2(float(entry["x"]), float(entry["y"])))
+    _origin = board_origin
+    _cell_size = override_cell_size if override_cell_size > 0.0 else cell_size
+    visible = not _cells.is_empty()
+    queue_redraw()
+
+func clear() -> void:
+    _cells.clear()
+    visible = false
+    queue_redraw()
+
+func _draw() -> void:
+    if _cells.is_empty():
+        return
+    for cell in _cells:
+        var pos := (cell + _origin + offset) * _cell_size
+        var rect := Rect2(pos, Vector2(_cell_size, _cell_size))
+        draw_rect(rect, fill_color, true)
+        if outline_thickness > 0.0:
+            draw_rect(rect, outline_color, false, outline_thickness)

--- a/scenes/piece/PiecePreview.tscn
+++ b/scenes/piece/PiecePreview.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/piece/PiecePreview.gd" id="1"]
+
+[node name="PiecePreview" type="Node2D"]
+script = ExtResource("1")
+visible = false

--- a/scripts/Board.gd
+++ b/scripts/Board.gd
@@ -1,0 +1,207 @@
+extends Node2D
+class_name Board
+
+const Shapes := preload("res://scripts/Shapes.gd")
+
+@export var columns: int = 10
+@export var rows: int = 10
+@export var cell_size: float = 32.0
+
+var grid: Array = []
+var undo_stack: Array = []
+var redo_stack: Array = []
+
+var current_piece: Array = []
+var current_origin: Vector2i = Vector2i.ZERO
+var current_rotation_steps: int = 0
+var flipped_horizontal: bool = false
+var preview_origin: Vector2 = Vector2.ZERO
+
+@onready var preview: PiecePreview = get_node_or_null("PiecePreview") as PiecePreview
+
+func _ready() -> void:
+    _initialize_grid()
+    update_preview()
+
+func _initialize_grid() -> void:
+    grid.clear()
+    for _y in range(rows):
+        var row: Array = []
+        for _x in range(columns):
+            row.append(null)
+        grid.append(row)
+    undo_stack.clear()
+    redo_stack.clear()
+
+func reset_board() -> void:
+    _initialize_grid()
+    current_piece.clear()
+    current_origin = Vector2i.ZERO
+    current_rotation_steps = 0
+    flipped_horizontal = false
+    update_preview()
+
+func set_current_piece(cells: Array, origin: Vector2i = Vector2i.ZERO) -> void:
+    current_piece = Shapes.normalize(cells)
+    current_origin = origin
+    current_rotation_steps = 0
+    flipped_horizontal = false
+    update_preview()
+
+func set_preview_origin(board_cell: Vector2) -> void:
+    preview_origin = board_cell
+    update_preview()
+
+func get_current_piece_cells() -> Array:
+    if current_piece.is_empty():
+        return []
+    var transformed := Shapes.rotate(current_piece, current_rotation_steps)
+    if flipped_horizontal:
+        transformed = Shapes.flip(transformed, true)
+    return transformed
+
+func get_transformed_global_cells(origin: Vector2i) -> Array:
+    var oriented := get_current_piece_cells()
+    var global_cells: Array = []
+    for cell in oriented:
+        global_cells.append(origin + cell)
+    return global_cells
+
+func is_in_bounds(cell: Vector2i) -> bool:
+    return cell.x >= 0 and cell.y >= 0 and cell.x < columns and cell.y < rows
+
+func is_cell_empty(cell: Vector2i) -> bool:
+    return is_in_bounds(cell) and grid[cell.y][cell.x] == null
+
+func can_place(piece_cells: Array, origin: Vector2i) -> bool:
+    for cell in piece_cells:
+        var board_cell := origin + cell
+        if not is_in_bounds(board_cell):
+            return false
+        if not is_cell_empty(board_cell):
+            return false
+    return true
+
+func can_place_current_piece(origin: Vector2i) -> bool:
+    return can_place(get_current_piece_cells(), origin)
+
+func place_piece(piece_cells: Array, origin: Vector2i, value := true, metadata := {}) -> bool:
+    if not can_place(piece_cells, origin):
+        return false
+    var record := {
+        "cells": [],
+        "before": [],
+        "after": [],
+        "metadata": metadata.duplicate(true) if metadata is Dictionary else metadata
+    }
+    for cell in piece_cells:
+        var board_cell := origin + cell
+        record["cells"].append(board_cell)
+        record["before"].append(grid[board_cell.y][board_cell.x])
+        record["after"].append(value)
+        grid[board_cell.y][board_cell.x] = value
+    undo_stack.append(record)
+    redo_stack.clear()
+    return true
+
+func place_current_piece(origin: Vector2i = current_origin, value := true, metadata := {}) -> bool:
+    var piece_cells := get_current_piece_cells()
+    var placed := place_piece(piece_cells, origin, value, metadata)
+    if placed:
+        current_origin = origin
+    return placed
+
+func undo() -> void:
+    if undo_stack.is_empty():
+        return
+    var last_action := undo_stack.pop_back()
+    for index in range(last_action["cells"].size()):
+        var cell: Vector2i = last_action["cells"][index]
+        var value = last_action["before"][index]
+        grid[cell.y][cell.x] = value
+    redo_stack.append(last_action)
+    update_preview()
+
+func redo() -> void:
+    if redo_stack.is_empty():
+        return
+    var action := redo_stack.pop_back()
+    for index in range(action["cells"].size()):
+        var cell: Vector2i = action["cells"][index]
+        var value = action["after"][index]
+        grid[cell.y][cell.x] = value
+    undo_stack.append(action)
+    update_preview()
+
+func rotate_current_piece(clockwise: bool = true) -> void:
+    if current_piece.is_empty():
+        return
+    var delta := 1 if clockwise else -1
+    current_rotation_steps = (current_rotation_steps + delta) % 4
+    if current_rotation_steps < 0:
+        current_rotation_steps += 4
+    update_preview()
+
+func flip_current_piece() -> void:
+    if current_piece.is_empty():
+        return
+    flipped_horizontal = not flipped_horizontal
+    update_preview()
+
+func update_preview() -> void:
+    if preview == null:
+        return
+    var oriented := get_current_piece_cells()
+    if preview.has_method("show_shape"):
+        preview.show_shape(oriented, preview_origin, cell_size)
+
+func _unhandled_input(event: InputEvent) -> void:
+    if not (event is InputEventKey):
+        return
+    var key_event := event as InputEventKey
+    if not key_event.pressed or key_event.echo:
+        return
+    match key_event.keycode:
+        KEY_R:
+            rotate_current_piece(not key_event.shift_pressed)
+            accept_event()
+        KEY_F:
+            flip_current_piece()
+            accept_event()
+        KEY_Z:
+            if key_event.ctrl_pressed:
+                if key_event.shift_pressed:
+                    redo()
+                else:
+                    undo()
+                accept_event()
+        KEY_Y:
+            if key_event.ctrl_pressed:
+                redo()
+                accept_event()
+
+func on_rotate_button_pressed() -> void:
+    rotate_current_piece(true)
+
+func on_flip_button_pressed() -> void:
+    flip_current_piece()
+
+func on_undo_button_pressed() -> void:
+    undo()
+
+func on_redo_button_pressed() -> void:
+    redo()
+
+func get_cell_value(cell: Vector2i):
+    if not is_in_bounds(cell):
+        return null
+    return grid[cell.y][cell.x]
+
+func set_cell_value(cell: Vector2i, value) -> void:
+    if not is_in_bounds(cell):
+        return
+    grid[cell.y][cell.x] = value
+
+func clear_history() -> void:
+    undo_stack.clear()
+    redo_stack.clear()

--- a/scripts/Shapes.gd
+++ b/scripts/Shapes.gd
@@ -1,0 +1,82 @@
+extends Resource
+class_name Shapes
+
+## Utility helpers for manipulating polyomino style shapes.
+## Shapes are represented as arrays of Vector2i offsets (cells)
+## relative to an origin at (0, 0).
+
+static func _to_vector2i_array(shape: Array) -> Array:
+    var cells: Array = []
+    for entry in shape:
+        if entry is Vector2i:
+            cells.append(entry)
+        elif entry is Vector2:
+            cells.append(Vector2i(int(round(entry.x)), int(round(entry.y))))
+        elif entry is Array and entry.size() >= 2:
+            cells.append(Vector2i(int(entry[0]), int(entry[1])))
+        elif entry is Dictionary and entry.has("x") and entry.has("y"):
+            cells.append(Vector2i(int(entry["x"]), int(entry["y"])))
+        else:
+            push_error("Unsupported shape entry: %s" % entry)
+    return cells
+
+static func _normalize(cells: Array) -> Array:
+    if cells.is_empty():
+        return []
+    var min_x := cells[0].x
+    var min_y := cells[0].y
+    for cell in cells:
+        min_x = mini(min_x, cell.x)
+        min_y = mini(min_y, cell.y)
+    var normalized: Array = []
+    for cell in cells:
+        normalized.append(Vector2i(cell.x - min_x, cell.y - min_y))
+    return normalized
+
+static func rotate(shape, steps: int = 1, normalize := true):
+    ## Rotate a shape in 90° steps (clockwise).
+    ## Accepts either an Array of Vector2(i) offsets or a Dictionary
+    ## containing a `cells` Array. Returns a deep copy.
+    var steps_local := int(steps) % 4
+    if steps_local < 0:
+        steps_local += 4
+    if shape is Dictionary and shape.has("cells"):
+        var clone := shape.duplicate(true)
+        clone["cells"] = rotate(shape["cells"], steps_local, normalize)
+        return clone
+
+    var cells := _to_vector2i_array(shape)
+    for _i in range(steps_local):
+        for index in range(cells.size()):
+            var cell: Vector2i = cells[index]
+            cells[index] = Vector2i(-cell.y, cell.x)
+    return _normalize(cells) if normalize else cells
+
+static func flip(shape, horizontal: bool = true, normalize := true):
+    ## Mirror a shape either horizontally (default) or vertically.
+    ## Accepts the same formats as `rotate` and returns a deep copy.
+    if shape is Dictionary and shape.has("cells"):
+        var clone := shape.duplicate(true)
+        clone["cells"] = flip(shape["cells"], horizontal, normalize)
+        return clone
+
+    var cells := _to_vector2i_array(shape)
+    for index in range(cells.size()):
+        var cell: Vector2i = cells[index]
+        if horizontal:
+            cells[index] = Vector2i(-cell.x, cell.y)
+        else:
+            cells[index] = Vector2i(cell.x, -cell.y)
+    return _normalize(cells) if normalize else cells
+
+static func rotate_counter_clockwise(shape, normalize := true):
+    return rotate(shape, -1, normalize)
+
+static func rotate_clockwise(shape, normalize := true):
+    return rotate(shape, 1, normalize)
+
+static func flip_vertical(shape, normalize := true):
+    return flip(shape, false, normalize)
+
+static func normalize(shape: Array) -> Array:
+    return _normalize(_to_vector2i_array(shape))


### PR DESCRIPTION
## Summary
- add board logic helpers for bounds checking, undo/redo stacks, and input bindings
- provide shape rotation and flipping utilities plus a ghost preview scene
- document new controls and manual test plan in the README

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8e98a1c048327bbd6fe18b2975a2b